### PR TITLE
Remove > typo for misstake form link

### DIFF
--- a/CompatibilityReport/Reporter/HtmlTemplates/HtmlReportTemplate.tt
+++ b/CompatibilityReport/Reporter/HtmlTemplates/HtmlReportTemplate.tt
@@ -177,7 +177,7 @@
         <li> Having issues with a mod? Make a comment on its Workshop page so the author knows.</li>
         <li> Abandoned mods can still work fine. They're just unlikely to get updates.</li>
         <li> Mod compatible, but not working? Try unsubscribe and resubscribe (while not in game).</li>
-        <li> Found a mistake? Please fill out this <a href="https://forms.gle/PvezwfpgS1V1DHqA9>">form</a>.</li>
+        <li> Found a mistake? Please fill out this <a href="https://forms.gle/PvezwfpgS1V1DHqA9">form</a>.</li>
     </ul>
 
 <#  // Is outdated


### PR DESCRIPTION
Removes the > at the end of the "Found a mistake? Please fill out this form." link for the HTML report, sending the user to the correct link, instead of getting a firebase error page.